### PR TITLE
Fixed logic for pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -776,12 +776,9 @@ $jql = 'project not in (TEST)  and assignee = currentUser() and status in (Resol
 
 try {
     $issueService = new IssueService();
-
-    $pagination = -1;
-  
+    
     $startAt = 0;	//the index of the first issue to return (0-based)    
     $maxResult = 3;	// the maximum number of issues to return (defaults to 50). 
-    $totalCount = -1;	// the number of issues to return
   
     // first fetch
     $ret = $issueService->search($jql, $startAt, $maxResult);
@@ -792,10 +789,10 @@ try {
         print (sprintf("%s %s \n", $issue->key, $issue->fields->summary));
     }
   	
-    // fetch remained data
-    $page = $totalCount / $maxResult;
+    // fetch remaining data
+    $startAt += $maxResult;
 
-    for ($startAt = 1; $startAt < $page; $startAt++) {
+    while($startAt < $totalCount){
         $ret = $issueService->search($jql, $startAt, $maxResult);
 
         print ("\nPaging $startAt\n");
@@ -803,6 +800,7 @@ try {
         foreach ($ret->issues as $issue) {
             print (sprintf("%s %s \n", $issue->key, $issue->fields->summary));
         }
+	$startAt += $maxResult;
     }     
 } catch (JiraException $e) {
     $this->assertTrue(false, 'testSearch Failed : '.$e->getMessage());


### PR DESCRIPTION
The previous code would uses "relative" pages. If we had a start at of 0 and a max result of 50, with 101 tickets, we would get three batches of tickets, but not the correct 3 batches.

We would get 0-49, 1-50, and 2-3, rather than the desired (0-49, 50 - 99, 99 - 100)